### PR TITLE
Add on-page status bar indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ Built after too many coding sessions where a single ChatGPT tab would start eati
 
 **User experience**
 
-- **Configurable** – choose how many recent messages to keep
-- **Optional preservation** – keep system/tool messages beyond the normal limit
-- **Scroll-aware** – trimming pauses automatically while you scroll up to review history
+- **Configurable** – choose how many recent messages to keep (1–100)
+- **Status indicator** – optional on-page pill showing trim statistics
 - **Reversible** – refresh the page to restore the full conversation
 
 **Privacy**
@@ -106,10 +105,8 @@ When you want to see the full history again:
 ### Settings
 
 - **Extension enabled** – master on/off toggle.
-- **Keep last N messages** – how many messages remain visible in the DOM.
-- **Preserve system/tool messages** – keeps system & tool messages beyond the normal limit.
-- **Pause when scrolled up** – trimming stops while you're reading older parts of the conversation.
-- **Debug mode** – logs internal events to the console for troubleshooting.
+- **Keep last N messages** – how many messages remain visible in the DOM (1–100).
+- **Show status bar** – display a floating pill with trim statistics.
 - **Refresh** – reloads the page to restore all messages.
 
 ### Keyboard accessibility

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,269 @@
+# Development Guide
+
+## Prerequisites
+
+- Node.js >= 18
+- npm >= 9
+- Firefox >= 115 (or Firefox Developer Edition)
+
+## Quick Start
+
+```bash
+# Clone the repository
+git clone https://github.com/11me/light-session.git
+cd light-session
+
+# Install dependencies
+npm install
+
+# Build the extension
+npm run build
+
+# Start development with auto-reload
+npm run dev
+```
+
+## Project Structure
+
+```
+light-session/
+├── extension/
+│   ├── src/
+│   │   ├── content/           # Content scripts (injected into ChatGPT)
+│   │   │   ├── content.ts     # Entry point, lifecycle management
+│   │   │   ├── trimmer.ts     # Core trimming state machine
+│   │   │   ├── status-bar.ts  # On-page status indicator
+│   │   │   ├── dom-helpers.ts # DOM traversal utilities
+│   │   │   ├── observers.ts   # MutationObserver setup
+│   │   │   └── stream-detector.ts
+│   │   ├── background/        # Background service worker
+│   │   │   └── background.ts  # Settings management, message handling
+│   │   ├── popup/             # Extension popup UI
+│   │   │   ├── popup.html
+│   │   │   ├── popup.css
+│   │   │   └── popup.ts
+│   │   └── shared/            # Shared code between all contexts
+│   │       ├── types.ts       # TypeScript interfaces
+│   │       ├── constants.ts   # Configuration constants
+│   │       ├── storage.ts     # Settings persistence
+│   │       ├── messages.ts    # Runtime messaging
+│   │       └── logger.ts      # Debug logging
+│   ├── popup/                 # Compiled popup files
+│   ├── icons/                 # Extension icons
+│   ├── manifest.json          # Firefox extension manifest (MV3)
+│   └── .dev                   # Dev mode marker (not committed)
+├── docs/                      # Documentation
+├── build.js                   # Build script (esbuild)
+├── package.json
+└── tsconfig.json
+```
+
+## Architecture
+
+### State Machine
+
+The trimmer uses a simplified state machine:
+
+```
+IDLE ←→ OBSERVING
+```
+
+- **IDLE**: Extension disabled or not initialized
+- **OBSERVING**: Watching for DOM changes via MutationObserver
+
+Trimming is controlled by the `trimScheduled` flag rather than dedicated states.
+The `evaluateTrim()` function handles the actual trim logic synchronously when called.
+
+### Key Components
+
+| Component | Responsibility |
+|-----------|----------------|
+| `content.ts` | Entry point, navigation handling, lifecycle |
+| `trimmer.ts` | State machine, trim logic, batch execution |
+| `status-bar.ts` | Floating pill UI showing trim stats |
+| `dom-helpers.ts` | Finding conversation nodes, classification |
+| `background.ts` | Settings storage, message routing |
+
+### Data Flow
+
+```
+ChatGPT DOM
+    │
+    ▼
+MutationObserver (debounced 75ms)
+    │
+    ▼
+evaluateTrim()
+    │
+    ├─ Check preconditions (enabled, not streaming, etc.)
+    │
+    ├─ Build active thread (find message nodes)
+    │
+    ├─ Calculate overflow (nodes.length - keepCount)
+    │
+    └─ Execute trim (batched via requestIdleCallback)
+         │
+         └─ Update status bar
+```
+
+## Build System
+
+Uses esbuild for fast TypeScript compilation:
+
+```bash
+# Single build
+npm run build
+
+# Watch mode (rebuilds on changes)
+npm run watch
+```
+
+Build outputs:
+- `extension/dist/content.js` — Content script bundle
+- `extension/dist/background.js` — Background script bundle
+- `extension/popup/popup.js` — Popup script bundle
+- `extension/popup/popup.html` — Copied from src
+- `extension/popup/popup.css` — Copied from src
+
+## Development Workflow
+
+### 1. Enable Dev Mode
+
+Create a `.dev` file to show debug options in the popup:
+
+```bash
+touch extension/.dev
+```
+
+This file is gitignored and won't be included in releases.
+
+### 2. Load Extension in Firefox
+
+**Option A: Using web-ext (recommended)**
+
+```bash
+npm run dev           # Firefox Developer Edition
+npm run dev:stable    # Firefox stable
+```
+
+This watches for changes and auto-reloads the extension.
+
+**Option B: Manual loading**
+
+1. Open `about:debugging#/runtime/this-firefox`
+2. Click "Load Temporary Add-on"
+3. Select `extension/manifest.json`
+
+### 3. Testing Changes
+
+1. Make code changes
+2. Build: `npm run build` (or use watch mode)
+3. If using manual loading, click "Reload" in about:debugging
+4. Open/refresh a ChatGPT conversation
+5. Check the browser console for debug logs (if debug mode enabled)
+
+### 4. Debug Logging
+
+Enable debug mode in the popup to see detailed logs:
+
+```
+[LS:DEBUG] evaluateTrim called
+[LS:DEBUG] Settings: enabled=true, keep=10
+[LS:DEBUG] Building active thread...
+[LS:DEBUG] Built thread with 25 nodes
+[LS:INFO] Executing trim: Removing 15 nodes (keeping 10)
+```
+
+## npm Scripts
+
+| Script | Description |
+|--------|-------------|
+| `npm run build` | Build once |
+| `npm run watch` | Build and watch for changes |
+| `npm run dev` | Run in Firefox Developer Edition with auto-reload |
+| `npm run dev:stable` | Run in Firefox stable |
+| `npm run lint` | Run ESLint |
+| `npm run format` | Format code with Prettier |
+| `npm run package` | Create .xpi for distribution |
+| `npm run clean` | Remove build artifacts |
+
+## Settings Schema
+
+Settings are stored in `browser.storage.local` under the key `ls_settings`:
+
+```typescript
+interface LsSettings {
+  version: 1;           // Schema version for migrations
+  enabled: boolean;     // Master toggle
+  keep: number;         // Messages to keep (1-100)
+  showStatusBar: boolean; // Show on-page indicator
+  debug: boolean;       // Enable console logging
+}
+```
+
+Default values are defined in `shared/constants.ts`.
+
+## Status Bar
+
+The status bar is a floating pill in the bottom-right corner:
+
+- **Green**: Actively trimming (`LightSession · last 10 · 17 trimmed`)
+- **Gray**: Waiting or all visible (`LightSession · all 5 visible`)
+
+Position: `bottom: 50px`, `right: 24px`
+
+The accumulated trim count persists during the session and resets on:
+- Page refresh
+- Navigation to a different chat
+
+## Common Tasks
+
+### Adding a New Setting
+
+1. Add to `LsSettings` interface in `shared/types.ts`
+2. Add default value in `shared/constants.ts`
+3. Add validation in `shared/storage.ts`
+4. Add UI control in `popup/popup.html`
+5. Add handler in `popup/popup.ts`
+6. Use setting in content script as needed
+
+### Modifying Trim Behavior
+
+Core logic is in `trimmer.ts`:
+- `evaluateTrim()` — Main evaluation function
+- `calculateKeepCount()` — How many nodes to keep
+- `executeTrim()` — Batched DOM removal
+
+### Updating Selectors
+
+If ChatGPT changes their DOM structure, update selectors in:
+- `shared/constants.ts` — `SELECTOR_TIERS` array (multi-tier fallback strategy)
+- `dom-helpers.ts` — `buildActiveThread()` and selector logic
+
+The extension uses a tiered selector approach:
+- **Tier A**: Data attributes (`[data-message-id]`)
+- **Tier B**: Test IDs and specific classes
+- **Tier C**: Structural fallbacks with heuristics
+
+## Troubleshooting
+
+### Extension not loading
+
+- Check `about:debugging` for errors
+- Verify `manifest.json` is valid
+- Check browser console for permission errors
+
+### Trimming not working
+
+1. Enable debug mode
+2. Check console for `[LS:*]` logs
+3. Common issues:
+   - Conversation root not found (selector mismatch)
+   - Streaming detected (waits for completion)
+   - Not enough messages (minimum threshold)
+
+### Status bar not appearing
+
+- Check `showStatusBar` setting is enabled
+- Verify content script is running (check console)
+- Inspect DOM for `#lightsession-status-bar` element

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -48,6 +48,15 @@
         <p class="setting-description">Adjust how many recent messages to display</p>
       </div>
 
+      <!-- Show Status Bar -->
+      <div class="setting-group">
+        <label class="checkbox-container">
+          <input type="checkbox" id="showStatusBarCheckbox" aria-label="Show status bar">
+          <span class="checkbox-label">Show status bar</span>
+        </label>
+        <p class="setting-description">Display trimming statistics on the ChatGPT page</p>
+      </div>
+
       <!-- Debug Mode (only shown in dev mode) -->
       <div class="setting-group" id="debugGroup" style="display: none;">
         <label class="checkbox-container">

--- a/extension/src/content/status-bar.ts
+++ b/extension/src/content/status-bar.ts
@@ -1,0 +1,249 @@
+/**
+ * LightSession for ChatGPT - Status Bar
+ * Compact floating pill indicator showing trimming statistics
+ */
+
+const STATUS_BAR_ID = 'lightsession-status-bar';
+
+export interface StatusBarStats {
+  totalMessages: number;
+  visibleMessages: number;
+  trimmedMessages: number;
+  keepLastN: number;
+}
+
+type StatusBarState = 'active' | 'waiting' | 'all-visible' | 'unrecognized';
+
+let currentStats: StatusBarStats | null = null;
+let isVisible = true;
+let accumulatedTrimmed = 0;
+
+/**
+ * Get or create the status bar element
+ */
+function getOrCreateStatusBar(): HTMLElement | null {
+  let bar = document.getElementById(STATUS_BAR_ID);
+  if (bar) {
+    return bar;
+  }
+
+  bar = document.createElement('div');
+  bar.id = STATUS_BAR_ID;
+  bar.setAttribute('role', 'status');
+  bar.setAttribute('aria-live', 'polite');
+
+  applyStatusBarStyles(bar);
+
+  document.body.appendChild(bar);
+
+  return bar;
+}
+
+/**
+ * Apply inline styles to the status bar (compact pill, bottom-right)
+ */
+function applyStatusBarStyles(bar: HTMLElement): void {
+  Object.assign(bar.style, {
+    position: 'fixed',
+    bottom: '50px',
+    right: '24px',
+    zIndex: '10000',
+    padding: '4px 10px',
+    fontSize: '11px',
+    fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+    fontWeight: '500',
+    color: '#e5e7eb',
+    backgroundColor: 'rgba(15, 23, 42, 0.9)',
+    border: '1px solid rgba(55, 65, 81, 0.9)',
+    borderRadius: '9999px',
+    boxShadow: '0 2px 8px rgba(0, 0, 0, 0.3)',
+    backdropFilter: 'blur(4px)',
+    maxWidth: '60%',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    pointerEvents: 'none',
+    transition: 'opacity 0.2s ease',
+  });
+}
+
+/**
+ * Get status bar text based on current state (short format for pill)
+ */
+function getStatusText(stats: StatusBarStats): { text: string; state: StatusBarState } {
+  if (stats.trimmedMessages > 0) {
+    return {
+      text: `LightSession · last ${stats.keepLastN} · ${stats.trimmedMessages} trimmed`,
+      state: 'active',
+    };
+  }
+
+  if (stats.totalMessages === 0) {
+    return {
+      text: 'LightSession · waiting for messages…',
+      state: 'waiting',
+    };
+  }
+
+  if (stats.totalMessages <= stats.keepLastN) {
+    return {
+      text: `LightSession · all ${stats.totalMessages} visible`,
+      state: 'all-visible',
+    };
+  }
+
+  return {
+    text: `LightSession · ${stats.visibleMessages} visible`,
+    state: 'active',
+  };
+}
+
+/**
+ * Apply state-specific styling
+ */
+function applyStateStyles(bar: HTMLElement, state: StatusBarState): void {
+  // Reset to default
+  bar.style.opacity = '1';
+  bar.style.color = '#e5e7eb';
+  bar.style.backgroundColor = 'rgba(15, 23, 42, 0.9)';
+  bar.style.borderColor = 'rgba(55, 65, 81, 0.9)';
+
+  switch (state) {
+    case 'active':
+      bar.style.color = '#6ee7b7';
+      bar.style.backgroundColor = 'rgba(6, 78, 59, 0.9)';
+      bar.style.borderColor = 'rgba(16, 185, 129, 0.5)';
+      break;
+    case 'waiting':
+      bar.style.color = '#9ca3af';
+      break;
+    case 'all-visible':
+      // Keep neutral styling
+      break;
+    case 'unrecognized':
+      bar.style.color = '#fcd34d';
+      bar.style.backgroundColor = 'rgba(120, 53, 15, 0.9)';
+      bar.style.borderColor = 'rgba(217, 119, 6, 0.5)';
+      break;
+  }
+}
+
+/**
+ * Update the status bar with new stats
+ */
+export function updateStatusBar(stats: StatusBarStats): void {
+  // Reset accumulated count when entering a new/empty chat
+  if (stats.totalMessages === 0) {
+    accumulatedTrimmed = 0;
+  }
+
+  // Accumulate trimmed count
+  if (stats.trimmedMessages > 0) {
+    accumulatedTrimmed += stats.trimmedMessages;
+  }
+
+  // Use accumulated count for display
+  const displayStats: StatusBarStats = {
+    ...stats,
+    trimmedMessages: accumulatedTrimmed,
+  };
+
+  currentStats = displayStats;
+
+  if (!isVisible) {
+    return;
+  }
+
+  const bar = getOrCreateStatusBar();
+  if (!bar) {
+    return;
+  }
+
+  const { text, state } = getStatusText(displayStats);
+  bar.textContent = text;
+  applyStateStyles(bar, state);
+}
+
+/**
+ * Show warning when ChatGPT layout is not recognized
+ */
+export function showLayoutNotRecognized(): void {
+  if (!isVisible) {
+    return;
+  }
+
+  const bar = getOrCreateStatusBar();
+  if (!bar) {
+    return;
+  }
+
+  bar.textContent = 'LightSession · layout not recognized';
+  applyStateStyles(bar, 'unrecognized');
+}
+
+/**
+ * Show the status bar
+ */
+export function showStatusBar(): void {
+  isVisible = true;
+  const bar = document.getElementById(STATUS_BAR_ID);
+
+  if (bar) {
+    bar.style.display = 'block';
+    if (currentStats) {
+      const { text, state } = getStatusText(currentStats);
+      bar.textContent = text;
+      applyStateStyles(bar, state);
+    }
+  } else if (currentStats) {
+    const newBar = getOrCreateStatusBar();
+    if (newBar) {
+      const { text, state } = getStatusText(currentStats);
+      newBar.textContent = text;
+      applyStateStyles(newBar, state);
+    }
+  }
+}
+
+/**
+ * Hide the status bar
+ */
+export function hideStatusBar(): void {
+  isVisible = false;
+  const bar = document.getElementById(STATUS_BAR_ID);
+
+  if (bar) {
+    bar.style.display = 'none';
+  }
+}
+
+/**
+ * Remove the status bar from DOM
+ */
+export function removeStatusBar(): void {
+  const bar = document.getElementById(STATUS_BAR_ID);
+  if (bar) {
+    bar.remove();
+  }
+  currentStats = null;
+  isVisible = false;
+  accumulatedTrimmed = 0;
+}
+
+/**
+ * Reset accumulated trimmed counter (call on chat navigation)
+ */
+export function resetAccumulatedTrimmed(): void {
+  accumulatedTrimmed = 0;
+}
+
+/**
+ * Set status bar visibility based on settings
+ */
+export function setStatusBarVisibility(visible: boolean): void {
+  if (visible) {
+    showStatusBar();
+  } else {
+    hideStatusBar();
+  }
+}

--- a/extension/src/popup/popup.html
+++ b/extension/src/popup/popup.html
@@ -48,26 +48,17 @@
         <p class="setting-description">Adjust how many recent messages to display</p>
       </div>
 
-      <!-- Preserve System/Tool Messages -->
+      <!-- Show Status Bar -->
       <div class="setting-group">
         <label class="checkbox-container">
-          <input type="checkbox" id="preserveSystemCheckbox" aria-label="Preserve system and tool messages">
-          <span class="checkbox-label">Preserve system/tool messages</span>
+          <input type="checkbox" id="showStatusBarCheckbox" aria-label="Show status bar">
+          <span class="checkbox-label">Show status bar</span>
         </label>
-        <p class="setting-description">Keep system and tool messages beyond normal limit</p>
+        <p class="setting-description">Display trimming statistics on the ChatGPT page</p>
       </div>
 
-      <!-- Pause on Scroll Up -->
-      <div class="setting-group">
-        <label class="checkbox-container">
-          <input type="checkbox" id="pauseOnScrollUpCheckbox" aria-label="Pause when scrolled up">
-          <span class="checkbox-label">Pause when scrolled up</span>
-        </label>
-        <p class="setting-description">Stop trimming while reviewing older messages</p>
-      </div>
-
-      <!-- Debug Mode -->
-      <div class="setting-group">
+      <!-- Debug Mode (only shown in dev mode) -->
+      <div class="setting-group" id="debugGroup" style="display: none;">
         <label class="checkbox-container">
           <input type="checkbox" id="debugCheckbox" aria-label="Enable debug logging">
           <span class="checkbox-label">Debug mode</span>
@@ -89,6 +80,6 @@
     </footer>
   </div>
 
-  <script src="../../dist/popup/popup.js"></script>
+  <script src="popup.js"></script>
 </body>
 </html>

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -10,6 +10,7 @@ import { sendMessageWithTimeout } from '../shared/messages';
 let enableToggle: HTMLInputElement;
 let keepSlider: HTMLInputElement;
 let keepValue: HTMLElement;
+let showStatusBarCheckbox: HTMLInputElement;
 let debugCheckbox: HTMLInputElement;
 let debugGroup: HTMLElement;
 let refreshButton: HTMLButtonElement;
@@ -91,6 +92,7 @@ async function initialize(): Promise<void> {
   enableToggle = document.getElementById('enableToggle') as HTMLInputElement;
   keepSlider = document.getElementById('keepSlider') as HTMLInputElement;
   keepValue = document.getElementById('keepValue') as HTMLElement;
+  showStatusBarCheckbox = document.getElementById('showStatusBarCheckbox') as HTMLInputElement;
   debugCheckbox = document.getElementById('debugCheckbox') as HTMLInputElement;
   debugGroup = document.getElementById('debugGroup') as HTMLElement;
   refreshButton = document.getElementById('refreshButton') as HTMLButtonElement;
@@ -109,6 +111,9 @@ async function initialize(): Promise<void> {
   enableToggle.addEventListener('change', handleEnableToggle);
   keepSlider.addEventListener('input', handleKeepSliderInput);
   keepSlider.addEventListener('change', handleKeepSliderChange);
+  if (showStatusBarCheckbox) {
+    showStatusBarCheckbox.addEventListener('change', handleShowStatusBarToggle);
+  }
   if (debugCheckbox) {
     debugCheckbox.addEventListener('change', handleDebugToggle);
   }
@@ -132,6 +137,9 @@ async function loadSettings(): Promise<void> {
     keepValue.textContent = settings.keep.toString();
     keepSlider.setAttribute('aria-valuenow', settings.keep.toString());
 
+    if (showStatusBarCheckbox) {
+      showStatusBarCheckbox.checked = settings.showStatusBar;
+    }
     if (debugCheckbox) {
       debugCheckbox.checked = settings.debug;
     }
@@ -191,6 +199,13 @@ function handleKeepSliderInput(): void {
 function handleKeepSliderChange(): void {
   const value = parseInt(keepSlider.value, 10);
   scheduleKeepUpdate(value, true);
+}
+
+/**
+ * Handle show status bar toggle
+ */
+function handleShowStatusBarToggle(): void {
+  updateSettings({ showStatusBar: showStatusBarCheckbox.checked });
 }
 
 /**

--- a/extension/src/shared/constants.ts
+++ b/extension/src/shared/constants.ts
@@ -13,8 +13,7 @@ export const DEFAULT_SETTINGS: Readonly<LsSettings> = {
   version: 1,
   enabled: true,
   keep: 10,
-  preserveSystem: true,
-  pauseOnScrollUp: true,
+  showStatusBar: true,
   debug: false,
 } as const;
 

--- a/extension/src/shared/storage.ts
+++ b/extension/src/shared/storage.ts
@@ -21,8 +21,7 @@ export function validateSettings(input: Partial<LsSettings>): LsSettings {
       VALIDATION.MIN_KEEP,
       Math.min(VALIDATION.MAX_KEEP, input.keep ?? DEFAULT_SETTINGS.keep)
     ),
-    preserveSystem: input.preserveSystem ?? DEFAULT_SETTINGS.preserveSystem,
-    pauseOnScrollUp: input.pauseOnScrollUp ?? DEFAULT_SETTINGS.pauseOnScrollUp,
+    showStatusBar: input.showStatusBar ?? DEFAULT_SETTINGS.showStatusBar,
     debug: input.debug ?? DEFAULT_SETTINGS.debug,
   };
 }

--- a/extension/src/shared/types.ts
+++ b/extension/src/shared/types.ts
@@ -11,8 +11,7 @@ export interface LsSettings {
   version: 1; // Schema version for future migrations
   enabled: boolean; // Toggle trimming on/off
   keep: number; // Message retention limit (1-100)
-  preserveSystem: boolean; // Preserve system/tool messages beyond limit
-  pauseOnScrollUp: boolean; // Pause trimming when user scrolls up
+  showStatusBar: boolean; // Show in-page status bar with trimming stats
   debug: boolean; // Enable debug logging
 }
 
@@ -50,8 +49,6 @@ export interface TrimmerState {
   trimScheduled: boolean; // Debounce flag
   lastTrimTime: number; // performance.now() of last trim
   conversationRoot: HTMLElement | null;
-  scrollContainer: HTMLElement | null;
-  isAtBottom: boolean; // Scroll position tracking
   settings: LsSettings; // Cached settings (refreshed on storage change)
 }
 


### PR DESCRIPTION
## Summary

- Add floating pill indicator showing trim statistics (bottom-right corner)
- Show "layout not recognized" warning when ChatGPT DOM structure changes
- Remove unused settings: `preserveSystem` and `pauseOnScrollUp`
- Add `showStatusBar` toggle to popup (enabled by default)
- Hide debug mode from end users (requires `.dev` file for dev mode)
- Implement watch mode in build script (`npm run watch`)
- Add `docs/development.md` with architecture and workflow guide

## Screenshots

Status bar shows trim count in bottom-right corner of ChatGPT page.

## Test plan

- [ ] Load extension in Firefox
- [ ] Open a long ChatGPT conversation (10+ messages)
- [ ] Verify status bar appears showing "X trimmed"
- [ ] Navigate to new chat — verify counter resets
- [ ] Toggle "Show status bar" in popup — verify pill hides/shows
- [ ] Disable extension — verify pill disappears