### PR TITLE
Add Support LightSession button to popup

### DIFF
--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -212,22 +212,64 @@ main {
   outline-offset: 2px;
 }
 
-/* Status Message */
+/* Footer */
 footer {
   margin-top: 12px;
-  padding-top: 12px;
+  padding-top: 10px;
   border-top: 1px solid #eee;
+  text-align: center;
 }
 
 .status {
   font-size: 12px;
-  text-align: center;
   min-height: 18px;
   color: #10a37f;
 }
 
+.status:empty {
+  display: none;
+}
+
 .status.error {
   color: #d9534f;
+}
+
+.ls-footer-support {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 12px;
+  border-radius: 999px;
+  border: 1px solid #ddd;
+  background: transparent;
+  font-size: 11px;
+  color: #555;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.ls-footer-heart {
+  filter: grayscale(0.3);
+}
+
+.ls-footer-support:hover {
+  background: rgba(16, 163, 127, 0.08);
+  border-color: #10a37f;
+  color: #10a37f;
+  transform: translateY(-1px);
+}
+
+.ls-footer-support:hover .ls-footer-heart {
+  filter: grayscale(0);
+}
+
+.ls-footer-support:active {
+  transform: translateY(0);
+}
+
+.ls-footer-support:focus {
+  outline: 2px solid #10a37f;
+  outline-offset: 2px;
 }
 
 /* Disabled State */

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -73,10 +73,15 @@
         </button>
         <p class="setting-description">Reload ChatGPT page to see all messages</p>
       </div>
+
     </main>
 
     <footer>
       <div id="status" class="status" role="status" aria-live="polite"></div>
+      <button class="ls-footer-support" id="supportLink">
+        <span class="ls-footer-heart">❤️</span>
+        <span>Support LightSession</span>
+      </button>
     </footer>
   </div>
 

--- a/extension/src/popup/popup.css
+++ b/extension/src/popup/popup.css
@@ -212,22 +212,64 @@ main {
   outline-offset: 2px;
 }
 
-/* Status Message */
+/* Footer */
 footer {
   margin-top: 12px;
-  padding-top: 12px;
+  padding-top: 10px;
   border-top: 1px solid #eee;
+  text-align: center;
 }
 
 .status {
   font-size: 12px;
-  text-align: center;
   min-height: 18px;
   color: #10a37f;
 }
 
+.status:empty {
+  display: none;
+}
+
 .status.error {
   color: #d9534f;
+}
+
+.ls-footer-support {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 12px;
+  border-radius: 999px;
+  border: 1px solid #ddd;
+  background: transparent;
+  font-size: 11px;
+  color: #555;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.ls-footer-heart {
+  filter: grayscale(0.3);
+}
+
+.ls-footer-support:hover {
+  background: rgba(16, 163, 127, 0.08);
+  border-color: #10a37f;
+  color: #10a37f;
+  transform: translateY(-1px);
+}
+
+.ls-footer-support:hover .ls-footer-heart {
+  filter: grayscale(0);
+}
+
+.ls-footer-support:active {
+  transform: translateY(0);
+}
+
+.ls-footer-support:focus {
+  outline: 2px solid #10a37f;
+  outline-offset: 2px;
 }
 
 /* Disabled State */

--- a/extension/src/popup/popup.html
+++ b/extension/src/popup/popup.html
@@ -73,10 +73,15 @@
         </button>
         <p class="setting-description">Reload ChatGPT page to see all messages</p>
       </div>
+
     </main>
 
     <footer>
       <div id="status" class="status" role="status" aria-live="polite"></div>
+      <button class="ls-footer-support" id="supportLink">
+        <span class="ls-footer-heart">❤️</span>
+        <span>Support LightSession</span>
+      </button>
     </footer>
   </div>
 

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -5,6 +5,7 @@
 
 import type { LsSettings } from '../shared/types';
 import { sendMessageWithTimeout } from '../shared/messages';
+import { SUPPORT_URL } from '../shared/constants';
 
 // UI Elements
 let enableToggle: HTMLInputElement;
@@ -15,6 +16,7 @@ let debugCheckbox: HTMLInputElement;
 let debugGroup: HTMLElement;
 let refreshButton: HTMLButtonElement;
 let statusElement: HTMLElement;
+let supportLink: HTMLButtonElement;
 
 // Debounce/throttle state for slider persistence
 let sliderDebounceTimeout: number | null = null;
@@ -118,6 +120,10 @@ async function initialize(): Promise<void> {
     debugCheckbox.addEventListener('change', handleDebugToggle);
   }
   refreshButton.addEventListener('click', () => void handleRefreshClick());
+
+  // Support link
+  supportLink = document.getElementById('supportLink') as HTMLButtonElement;
+  supportLink.addEventListener('click', handleSupportClick);
 }
 
 /**
@@ -244,6 +250,13 @@ async function handleRefreshClick(): Promise<void> {
     showStatus('Failed to refresh page', true);
     console.error('Failed to refresh:', error);
   }
+}
+
+/**
+ * Handle support button click
+ */
+function handleSupportClick(): void {
+  void browser.tabs.create({ url: SUPPORT_URL });
 }
 
 /**

--- a/extension/src/shared/constants.ts
+++ b/extension/src/shared/constants.ts
@@ -158,3 +158,9 @@ export const VALIDATION = {
    */
   MAX_KEEP: 100,
 } as const;
+
+// ============================================================================
+// External URLs
+// ============================================================================
+
+export const SUPPORT_URL = 'https://github.com/11me/light-session#support' as const;


### PR DESCRIPTION
## Summary

- Add pill-style "Support LightSession" button in popup footer
- Opens GitHub support page (`#support` anchor) in new tab
- Subtle hover effects with brand colors

## Changes

- `constants.ts`: Add `SUPPORT_URL` constant
- `popup.html`: Add button markup in footer
- `popup.css`: Pill button styles with hover animations
- `popup.ts`: Click handler using `browser.tabs.create()`

## Screenshot

Button appears as a subtle pill in the popup footer with hover effects (green highlight, lift animation).

## Test plan

- [ ] Popup opens without errors
- [ ] Button visible in footer
- [ ] Click opens new tab with correct URL
- [ ] Hover shows green highlight and lift effect