### PR TITLE
feat(ci): add Chrome Web Store publishing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,23 +34,45 @@ jobs:
       - name: Type check
         run: npm run build:types
 
-      - name: Build
-        run: npm run build
-
       - name: Get version from tag
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
-      - name: Create extension zip
+      # =========================================================================
+      # Firefox Build
+      # =========================================================================
+      - name: Build Firefox extension
+        run: npm run build:prod:firefox
+
+      - name: Create Firefox extension zip
         run: |
           cd extension
-          zip -r ../light-session-${{ steps.version.outputs.VERSION }}.zip \
+          zip -r ../light-session-${{ steps.version.outputs.VERSION }}-firefox.zip \
             manifest.json \
             dist/ \
             popup/ \
             icons/ \
             -x "*.map"
 
+      # =========================================================================
+      # Chrome Build
+      # =========================================================================
+      - name: Build Chrome extension
+        run: npm run build:prod:chrome
+
+      - name: Create Chrome extension zip
+        run: |
+          cd extension
+          zip -r ../light-session-${{ steps.version.outputs.VERSION }}-chrome.zip \
+            manifest.json \
+            dist/ \
+            popup/ \
+            icons/ \
+            -x "*.map"
+
+      # =========================================================================
+      # Source Archive
+      # =========================================================================
       - name: Create source zip
         run: |
           zip -r light-session-${{ steps.version.outputs.VERSION }}-source.zip \
@@ -68,15 +90,20 @@ jobs:
             docs/ \
             extension/src/ \
             extension/icons/ \
-            extension/manifest.json \
+            extension/manifest.firefox.json \
+            extension/manifest.chrome.json \
             tests/
 
+      # =========================================================================
+      # GitHub Release
+      # =========================================================================
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
           files: |
-            light-session-${{ steps.version.outputs.VERSION }}.zip
+            light-session-${{ steps.version.outputs.VERSION }}-firefox.zip
+            light-session-${{ steps.version.outputs.VERSION }}-chrome.zip
             light-session-${{ steps.version.outputs.VERSION }}-source.zip
           body: |
             ## LightSession v${{ steps.version.outputs.VERSION }}
@@ -86,19 +113,43 @@ jobs:
             **Firefox Add-ons (recommended):**
             [Install from AMO](https://addons.mozilla.org/en-US/firefox/addon/lightsession-for-chatgpt/)
 
-            **Manual install:**
-            1. Download `light-session-${{ steps.version.outputs.VERSION }}.zip`
+            **Chrome Web Store:**
+            [Install from Chrome Web Store](https://chrome.google.com/webstore/detail/lightsession-for-chatgpt/${{ secrets.CHROME_EXTENSION_ID }})
+
+            **Manual install (Firefox):**
+            1. Download `light-session-${{ steps.version.outputs.VERSION }}-firefox.zip`
             2. Open `about:debugging#/runtime/this-firefox` in Firefox
             3. Click "Load Temporary Add-on"
             4. Select the downloaded zip file
 
+            **Manual install (Chrome):**
+            1. Download `light-session-${{ steps.version.outputs.VERSION }}-chrome.zip`
+            2. Open `chrome://extensions` in Chrome
+            3. Enable "Developer mode"
+            4. Click "Load unpacked" and select the extracted folder
+
             ---
 
+      # =========================================================================
+      # Firefox Add-ons Publishing
+      # =========================================================================
       - name: Publish to Firefox Add-ons
         uses: browser-actions/release-firefox-addon@latest
         with:
           addon-id: ${{ secrets.FIREFOX_ADDON_ID }}
-          addon-path: light-session-${{ steps.version.outputs.VERSION }}.zip
+          addon-path: light-session-${{ steps.version.outputs.VERSION }}-firefox.zip
           auth-api-issuer: ${{ secrets.FIREFOX_API_ISSUER }}
           auth-api-secret: ${{ secrets.FIREFOX_API_SECRET }}
           release-note: "See release notes at https://github.com/11me/light-session/releases/tag/v${{ steps.version.outputs.VERSION }}"
+
+      # =========================================================================
+      # Chrome Web Store Publishing
+      # =========================================================================
+      - name: Publish to Chrome Web Store
+        uses: browser-actions/release-chrome-extension@latest
+        with:
+          extension-id: ${{ secrets.CHROME_EXTENSION_ID }}
+          extension-path: light-session-${{ steps.version.outputs.VERSION }}-chrome.zip
+          oauth-client-id: ${{ secrets.CHROME_CLIENT_ID }}
+          oauth-client-secret: ${{ secrets.CHROME_CLIENT_SECRET }}
+          oauth-refresh-token: ${{ secrets.CHROME_REFRESH_TOKEN }}

--- a/docs/development.md
+++ b/docs/development.md
@@ -277,3 +277,65 @@ The extension uses a tiered selector approach:
 - Check `showStatusBar` setting is enabled
 - Verify content script is running (check console)
 - Inspect DOM for `#lightsession-status-bar` element
+
+## Release Process
+
+Releases are automated via GitHub Actions when a tag is pushed:
+
+```bash
+# Create and push a release tag
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+The workflow builds both Firefox and Chrome versions, creates a GitHub Release,
+and publishes to both browser stores.
+
+### Required GitHub Secrets
+
+The following secrets must be configured in the repository settings:
+
+#### Firefox Add-ons
+
+| Secret | Description |
+|--------|-------------|
+| `FIREFOX_ADDON_ID` | AMO extension ID (e.g., `lightsession@example.com`) |
+| `FIREFOX_API_ISSUER` | JWT issuer from AMO API credentials |
+| `FIREFOX_API_SECRET` | JWT secret from AMO API credentials |
+
+#### Chrome Web Store
+
+| Secret | Description |
+|--------|-------------|
+| `CHROME_EXTENSION_ID` | Chrome extension ID (32-char alphanumeric) |
+| `CHROME_CLIENT_ID` | OAuth 2.0 client ID from Google Cloud Console |
+| `CHROME_CLIENT_SECRET` | OAuth 2.0 client secret |
+| `CHROME_REFRESH_TOKEN` | OAuth 2.0 refresh token for Chrome Web Store API |
+
+### Getting Chrome Web Store Credentials
+
+1. **Create a Google Cloud Project** at [console.cloud.google.com](https://console.cloud.google.com)
+2. **Enable the Chrome Web Store API** in the API Library
+3. **Create OAuth 2.0 credentials** (Desktop application type)
+4. **Get a refresh token** using the OAuth 2.0 flow:
+   - Use the client ID/secret to authorize
+   - Request scope: `https://www.googleapis.com/auth/chromewebstore`
+   - Exchange the authorization code for a refresh token
+
+For detailed instructions, see the [Chrome Web Store API documentation](https://developer.chrome.com/docs/webstore/using_webstore_api/).
+
+### Multi-Browser Build
+
+```bash
+# Build for Firefox
+npm run build:prod:firefox
+
+# Build for Chrome
+npm run build:prod:chrome
+
+# Build both (development)
+npm run build:firefox && npm run build:chrome
+```
+
+The build system automatically switches between `manifest.firefox.json` and
+`manifest.chrome.json` based on the target.

--- a/extension/src/shared/messages.ts
+++ b/extension/src/shared/messages.ts
@@ -33,8 +33,11 @@ export async function sendMessageWithTimeout<T extends RuntimeResponse>(
       ]);
 
       // Check Chrome lastError (set when no listener exists)
-      if (isChrome && chrome.runtime.lastError) {
-        throw new Error(chrome.runtime.lastError.message ?? 'Chrome runtime error');
+      if (isChrome) {
+        const lastError = (chrome as { runtime: { lastError?: { message?: string } } }).runtime.lastError;
+        if (lastError) {
+          throw new Error(lastError.message ?? 'Chrome runtime error');
+        }
       }
 
       // Validate response is not undefined (Chrome returns undefined if service worker inactive)


### PR DESCRIPTION
## Summary
- Build and publish both Firefox and Chrome extensions on release
- Create separate browser-specific zip files (`-firefox.zip`, `-chrome.zip`)
- Add Chrome Web Store publishing step using `browser-actions/release-chrome-extension`
- Update GitHub Release notes with both store links
- Document required GitHub secrets in `docs/development.md`
- Fix lint error in `messages.ts` for `chrome.runtime.lastError` typing

## Required GitHub Secrets

| Secret | Description |
|--------|-------------|
| `CHROME_EXTENSION_ID` | Chrome extension ID (32-char alphanumeric) |
| `CHROME_CLIENT_ID` | OAuth 2.0 client ID from Google Cloud Console |
| `CHROME_CLIENT_SECRET` | OAuth 2.0 client secret |
| `CHROME_REFRESH_TOKEN` | OAuth 2.0 refresh token for Chrome Web Store API |

## Test plan
- [ ] Verify workflow YAML syntax is valid
- [ ] Configure secrets in repository settings
- [ ] Test release by pushing a tag (e.g., `v1.7.0-rc.1`)