### PR TITLE
Popup toggle for collapsing long user messages

### DIFF
--- a/extension/manifest.chrome.json
+++ b/extension/manifest.chrome.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "LightSession Pro for ChatGPT",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "description": "Keep ChatGPT fast by keeping only the last N messages in the DOM. Local-only.",
   "icons": {
     "16": "icons/icon-16.png",

--- a/extension/manifest.firefox.json
+++ b/extension/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "LightSession Pro for ChatGPT",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "description": "Keep ChatGPT fast by keeping only the last N messages in the DOM. Local-only.",
   "icons": {
     "16": "icons/icon-16.png",

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -86,6 +86,27 @@
             </div>
           </label>
 
+          <!-- Collapse long user messages -->
+          <label class="ls-checkbox-row">
+            <div class="ls-checkbox-wrapper">
+              <input
+                type="checkbox"
+                id="collapseLongUserMessagesCheckbox"
+                class="ls-checkbox-input"
+                aria-label="Collapse long user messages"
+              >
+              <div class="ls-checkbox-box">
+                <svg class="ls-checkbox-check" viewBox="0 0 12 12" fill="none">
+                  <path d="M2 6l3 3 5-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </div>
+            </div>
+            <div class="ls-checkbox-label-group">
+              <span class="ls-checkbox-label">Collapse long user messages</span>
+              <span class="ls-checkbox-description">Reduce lag in long chats</span>
+            </div>
+          </label>
+
         </div>
       </section>
 

--- a/extension/src/content/content.ts
+++ b/extension/src/content/content.ts
@@ -174,7 +174,8 @@ function applySettings(settings: LsSettings): void {
   setUltraLeanMode(settings.ultraLean);
 
   // Collapse long user messages (presentation-only; local DOM feature)
-  if (settings.enabled) {
+  const shouldCollapseLongUserMessages = settings.enabled && settings.collapseLongUserMessages;
+  if (shouldCollapseLongUserMessages) {
     if (!userCollapse) {
       userCollapse = installUserCollapse();
     }

--- a/extension/src/content/content.ts
+++ b/extension/src/content/content.ts
@@ -21,6 +21,7 @@ import {
   setStatusBarVisibility,
 } from './status-bar';
 import { isEmptyChatView } from './chat-view';
+import { installUserCollapse, type UserCollapseController } from './user-collapse';
 
 
 // ============================================================================
@@ -57,6 +58,7 @@ let proxyReady = false;
 let emptyChatState = false;
 let emptyChatCheckTimer: number | null = null;
 let emptyChatObserver: MutationObserver | null = null;
+let userCollapse: UserCollapseController | null = null;
 
 // ============================================================================
 // Page Script Communication
@@ -170,6 +172,17 @@ function applySettings(settings: LsSettings): void {
 
   // Apply Ultra Lean CSS mode (works independently of trimmer)
   setUltraLeanMode(settings.ultraLean);
+
+  // Collapse long user messages (presentation-only; local DOM feature)
+  if (settings.enabled) {
+    if (!userCollapse) {
+      userCollapse = installUserCollapse();
+    }
+    userCollapse.enable();
+  } else if (userCollapse) {
+    userCollapse.teardown();
+    userCollapse = null;
+  }
 
   logDebug('Settings applied:', settings);
 }

--- a/extension/src/content/user-collapse.ts
+++ b/extension/src/content/user-collapse.ts
@@ -1,0 +1,404 @@
+/**
+ * LightSession for ChatGPT - Collapse long user messages (presentation-only)
+ *
+ * Constraints:
+ * - Do not truncate or rewrite message text content (no innerHTML rewriting).
+ * - Clamp only the text container so attachments remain visible.
+ * - Target chatgpt.com + chat.openai.com using observed DOM anchors.
+ */
+
+import { logDebug, logWarn } from '../shared/logger';
+
+const STYLE_ID = 'lightsession-user-collapse-styles';
+const PROCESSED_ATTR = 'data-ls-uc-processed';
+const STATE_ATTR = 'data-ls-uc-state'; // "collapsed" | "expanded"
+
+const USER_ROOT_SELECTOR = '[data-message-author-role="user"][data-message-id]';
+const ANY_ROLE_ROOT_SELECTOR = '[data-message-author-role][data-message-id]';
+const BUBBLE_SELECTOR = '.user-message-bubble-color';
+const TEXT_SELECTORS = ['.whitespace-pre-wrap', '.markdown.prose', '.markdown', '.prose'] as const;
+
+const COLLAPSED_MAX_HEIGHT_PX = 240;
+const PINNED_TO_BOTTOM_PX = 120;
+
+type TeardownFn = () => void;
+
+function isTargetHost(): boolean {
+  const h = location.hostname;
+  return h === 'chatgpt.com' || h === 'chat.openai.com';
+}
+
+function ensureStyles(): void {
+  if (document.getElementById(STYLE_ID)) return;
+
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = `
+/* LightSession: user message collapse */
+.ls-uc-bubble { position: relative; }
+.ls-uc-text { position: relative; }
+
+.ls-uc-toggle {
+  position: absolute;
+  right: 10px;
+  bottom: 8px;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid rgba(0,0,0,.14);
+  border-radius: 9999px;
+  padding: 4px 10px;
+  font: 600 12px/1 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: rgba(255,255,255,.92);
+  color: rgba(17,24,39,.92);
+  backdrop-filter: blur(6px);
+  cursor: pointer;
+}
+.ls-uc-toggle:hover { background: rgba(255,255,255,.98); }
+.ls-uc-toggle:focus-visible {
+  outline: 2px solid rgba(37, 99, 235, .9);
+  outline-offset: 2px;
+}
+
+/* Clamp only the text container */
+.ls-uc-bubble[${STATE_ATTR}="collapsed"] .ls-uc-text {
+  max-height: ${COLLAPSED_MAX_HEIGHT_PX}px;
+  overflow: hidden;
+}
+.ls-uc-bubble[${STATE_ATTR}="expanded"] .ls-uc-text {
+  max-height: 99999px; /* large so content isn't truncated; allows transition */
+  overflow: visible;
+}
+.ls-uc-bubble .ls-uc-text { transition: max-height 180ms ease; }
+@media (prefers-reduced-motion: reduce) {
+  .ls-uc-bubble .ls-uc-text { transition: none; }
+}
+
+/* Fade overlay (pseudo-element; pointer-events none) */
+.ls-uc-bubble[${STATE_ATTR}="collapsed"] .ls-uc-text::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 54px;
+  pointer-events: none;
+  background: linear-gradient(to bottom, rgba(0,0,0,0), var(--ls-uc-fade-to, rgba(255,255,255,1)));
+}
+`;
+  document.head.appendChild(style);
+}
+
+function removeStyles(): void {
+  document.getElementById(STYLE_ID)?.remove();
+}
+
+function getMain(): HTMLElement | null {
+  return document.querySelector('main');
+}
+
+function findTextContainer(bubble: Element): HTMLElement | null {
+  for (const sel of TEXT_SELECTORS) {
+    const el = bubble.querySelector<HTMLElement>(sel);
+    if (el) return el;
+  }
+  return null;
+}
+
+function safeIdFragment(input: string): string {
+  const out = input.replace(/[^a-zA-Z0-9_-]/g, '_');
+  return out.length > 0 ? out : 'x';
+}
+
+function findLca(elements: Element[]): Element | null {
+  if (elements.length === 0) return null;
+  let current: Element | null = elements[0];
+  while (current) {
+    let ok = true;
+    for (let i = 1; i < elements.length; i++) {
+      if (!current.contains(elements[i])) {
+        ok = false;
+        break;
+      }
+    }
+    if (ok) return current;
+    current = current.parentElement;
+  }
+  return null;
+}
+
+function deriveMessageListContainer(main: HTMLElement): HTMLElement {
+  // Tiered selectors first (fast).
+  const byTurns = main.querySelector<HTMLElement>('[data-testid="conversation-turn"]');
+  if (byTurns?.parentElement) return byTurns.parentElement;
+
+  const byTurnsContainer = main.querySelector<HTMLElement>('[data-testid="conversation-turns"]');
+  if (byTurnsContainer) return byTurnsContainer;
+
+  // LCA fallback using observed anchors.
+  const roots = Array.from(main.querySelectorAll<HTMLElement>(ANY_ROLE_ROOT_SELECTOR)).slice(0, 12);
+  const lca = findLca(roots);
+  if (lca && lca instanceof HTMLElement) return lca;
+
+  // Last resort: main itself.
+  return main;
+}
+
+function deriveScrollContainer(start: HTMLElement): HTMLElement {
+  // Prefer a scrollable ancestor near the message list, otherwise fall back to scrollingElement.
+  let el: HTMLElement | null = start;
+  while (el && el !== document.body && el !== document.documentElement) {
+    const cs = getComputedStyle(el);
+    const oy = cs.overflowY;
+    const scrollable = (oy === 'auto' || oy === 'scroll') && el.scrollHeight > el.clientHeight + 1;
+    if (scrollable) return el;
+    el = el.parentElement;
+  }
+
+  const se = document.scrollingElement;
+  if (se && se instanceof HTMLElement) return se;
+  return document.documentElement;
+}
+
+function isPinnedToBottom(scroller: HTMLElement): boolean {
+  const remaining = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight;
+  return remaining < PINNED_TO_BOTTOM_PX;
+}
+
+function preserveScrollAfterHeightChange(
+  scroller: HTMLElement,
+  prevScrollTop: number,
+  prevScrollHeight: number,
+  wasPinned: boolean
+): void {
+  const nextScrollHeight = scroller.scrollHeight;
+  if (wasPinned) {
+    scroller.scrollTop = Math.max(0, nextScrollHeight - scroller.clientHeight);
+    return;
+  }
+  const delta = nextScrollHeight - prevScrollHeight;
+  scroller.scrollTop = prevScrollTop + delta;
+}
+
+function ensureButton(bubble: HTMLElement, textId: string): HTMLButtonElement {
+  let btn = bubble.querySelector<HTMLButtonElement>('button.ls-uc-toggle');
+  if (btn) {
+    btn.setAttribute('aria-controls', textId);
+    return btn;
+  }
+
+  btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'ls-uc-toggle';
+  btn.setAttribute('aria-controls', textId);
+  bubble.appendChild(btn);
+  return btn;
+}
+
+function updateButtonUi(btn: HTMLButtonElement, expanded: boolean): void {
+  btn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+  btn.textContent = expanded ? 'Show less' : 'Show more';
+}
+
+function applyFadeColor(bubble: HTMLElement, text: HTMLElement): void {
+  // Use the computed background of the bubble to blend the fade overlay.
+  const bg = getComputedStyle(bubble).backgroundColor;
+  if (bg) {
+    text.style.setProperty('--ls-uc-fade-to', bg);
+  }
+}
+
+function removeCollapseUi(root: HTMLElement, bubble: HTMLElement, text: HTMLElement): void {
+  bubble.removeAttribute(STATE_ATTR);
+  bubble.classList.remove('ls-uc-bubble');
+  bubble.querySelector('button.ls-uc-toggle')?.remove();
+  text.classList.remove('ls-uc-text');
+  text.style.removeProperty('--ls-uc-fade-to');
+  root.removeAttribute(PROCESSED_ATTR);
+}
+
+function ensureCollapseUi(root: HTMLElement, bubble: HTMLElement, text: HTMLElement): void {
+  root.setAttribute(PROCESSED_ATTR, '1');
+
+  bubble.classList.add('ls-uc-bubble');
+  text.classList.add('ls-uc-text');
+  applyFadeColor(bubble, text);
+
+  const messageId = root.getAttribute('data-message-id') || '';
+  const textId = text.id || `ls-uc-text-${safeIdFragment(messageId)}`;
+  text.id = textId;
+
+  if (!bubble.getAttribute(STATE_ATTR)) {
+    bubble.setAttribute(STATE_ATTR, 'collapsed');
+  }
+
+  const btn = ensureButton(bubble, textId);
+  updateButtonUi(btn, bubble.getAttribute(STATE_ATTR) === 'expanded');
+
+  logDebug('User collapse applied for message:', messageId);
+}
+
+function processUserMessageRoot(root: HTMLElement): void {
+  const bubble = root.querySelector<HTMLElement>(BUBBLE_SELECTOR);
+  if (!bubble) return;
+
+  const text = findTextContainer(bubble);
+  if (!text) return;
+
+  // Measure for "long" before clamping. Caller batches this in rAF.
+  const fullHeight = text.scrollHeight;
+  const isLong = fullHeight > COLLAPSED_MAX_HEIGHT_PX + 24;
+  const hasUi = root.hasAttribute(PROCESSED_ATTR) || !!bubble.querySelector('button.ls-uc-toggle');
+
+  if (!isLong) {
+    if (hasUi) removeCollapseUi(root, bubble, text);
+    return;
+  }
+
+  ensureCollapseUi(root, bubble, text);
+}
+
+function collectUserRootsFromAddedNode(node: unknown): HTMLElement[] {
+  if (!(node instanceof HTMLElement)) return [];
+
+  const out: HTMLElement[] = [];
+  if (node.matches(USER_ROOT_SELECTOR)) out.push(node);
+  const closest = node.closest<HTMLElement>(USER_ROOT_SELECTOR);
+  if (closest) out.push(closest);
+  out.push(...Array.from(node.querySelectorAll<HTMLElement>(USER_ROOT_SELECTOR)));
+  return out;
+}
+
+export interface UserCollapseController {
+  enable: () => void;
+  teardown: TeardownFn;
+}
+
+export function installUserCollapse(): UserCollapseController {
+  let enabled = false;
+  let observer: MutationObserver | null = null;
+  let container: HTMLElement | null = null;
+  let scroller: HTMLElement | null = null;
+  const pendingRoots = new Set<HTMLElement>();
+  let rafScheduled = false;
+  let onDocClick: ((ev: MouseEvent) => void) | null = null;
+
+  const scheduleProcess = (): void => {
+    if (rafScheduled) return;
+    rafScheduled = true;
+    requestAnimationFrame(() => {
+      rafScheduled = false;
+      if (!enabled) return;
+      const wasPinned = scroller ? isPinnedToBottom(scroller) : false;
+
+      for (const root of pendingRoots) {
+        processUserMessageRoot(root);
+      }
+      pendingRoots.clear();
+
+      if (scroller && wasPinned) {
+        // Keep user pinned to bottom if they were pinned before we changed layout.
+        scroller.scrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+      }
+    });
+  };
+
+  const attachObserver = (): void => {
+    const main = getMain();
+    if (!main) return;
+
+    container = deriveMessageListContainer(main);
+    scroller = deriveScrollContainer(container);
+
+    observer = new MutationObserver((mutations: MutationRecord[]) => {
+      // Process only addedNodes.
+      for (const m of mutations) {
+        if (m.type !== 'childList') continue;
+        for (const n of m.addedNodes) {
+          const roots = collectUserRootsFromAddedNode(n);
+          for (const r of roots) pendingRoots.add(r);
+        }
+      }
+      if (pendingRoots.size > 0) scheduleProcess();
+    });
+
+    observer.observe(container, { childList: true, subtree: true });
+
+    // Initial scan.
+    const initial = Array.from(container.querySelectorAll<HTMLElement>(USER_ROOT_SELECTOR));
+    for (const r of initial) pendingRoots.add(r);
+    if (pendingRoots.size > 0) scheduleProcess();
+  };
+
+  const enableFn = (): void => {
+    if (enabled) return;
+    if (!isTargetHost()) return;
+
+    enabled = true;
+    ensureStyles();
+
+    // Single delegated click handler for toggles.
+    onDocClick = (ev: MouseEvent): void => {
+      if (!scroller) return;
+      const target = ev.target;
+      if (!(target instanceof Element)) return;
+      const btn = target.closest<HTMLButtonElement>('button.ls-uc-toggle');
+      if (!btn) return;
+      const bubble = btn.closest<HTMLElement>('.ls-uc-bubble');
+      if (!bubble) return;
+
+      const wasPinned = isPinnedToBottom(scroller);
+      const prevScrollTop = scroller.scrollTop;
+      const prevScrollHeight = scroller.scrollHeight;
+
+      const expanded = bubble.getAttribute(STATE_ATTR) === 'expanded';
+      bubble.setAttribute(STATE_ATTR, expanded ? 'collapsed' : 'expanded');
+      updateButtonUi(btn, !expanded);
+
+      requestAnimationFrame(() => {
+        preserveScrollAfterHeightChange(scroller!, prevScrollTop, prevScrollHeight, wasPinned);
+      });
+    };
+    document.addEventListener('click', onDocClick, true);
+
+    try {
+      attachObserver();
+    } catch (e) {
+      logWarn('User collapse failed to attach:', e);
+    }
+  };
+
+  const teardownFn = (): void => {
+    enabled = false;
+    rafScheduled = false;
+    pendingRoots.clear();
+
+    if (onDocClick) {
+      document.removeEventListener('click', onDocClick, true);
+      onDocClick = null;
+    }
+
+    if (observer) {
+      observer.disconnect();
+      observer = null;
+    }
+
+    // Remove UI affordances/classes.
+    const main = getMain();
+    const scope = main || document;
+    for (const root of Array.from(scope.querySelectorAll<HTMLElement>(USER_ROOT_SELECTOR))) {
+      const bubble = root.querySelector<HTMLElement>(BUBBLE_SELECTOR);
+      if (!bubble) continue;
+      const text = findTextContainer(bubble);
+      if (text) removeCollapseUi(root, bubble, text);
+    }
+
+    container = null;
+    scroller = null;
+
+    removeStyles();
+  };
+
+  return { enable: enableFn, teardown: teardownFn };
+}

--- a/extension/src/content/user-collapse.ts
+++ b/extension/src/content/user-collapse.ts
@@ -113,11 +113,15 @@ function safeIdFragment(input: string): string {
 
 function findLca(elements: Element[]): Element | null {
   if (elements.length === 0) return null;
-  let current: Element | null = elements[0];
+  // noUncheckedIndexedAccess: elements[0] is Element | undefined
+  const first = elements[0];
+  if (!first) return null;
+  let current: Element | null = first;
   while (current) {
     let ok = true;
-    for (let i = 1; i < elements.length; i++) {
-      if (!current.contains(elements[i])) {
+    // Avoid indexed access to keep types tight under noUncheckedIndexedAccess.
+    for (const el of elements.slice(1)) {
+      if (!current.contains(el)) {
         ok = false;
         break;
       }
@@ -315,7 +319,9 @@ export function installUserCollapse(): UserCollapseController {
       // Process only addedNodes.
       for (const m of mutations) {
         if (m.type !== 'childList') continue;
-        for (const n of m.addedNodes) {
+        // Avoid for..of over NodeList (requires DOM iterable lib typings).
+        for (let i = 0; i < m.addedNodes.length; i++) {
+          const n = m.addedNodes[i];
           const roots = collectUserRootsFromAddedNode(n);
           for (const r of roots) pendingRoots.add(r);
         }

--- a/extension/src/popup/popup.html
+++ b/extension/src/popup/popup.html
@@ -86,6 +86,27 @@
             </div>
           </label>
 
+          <!-- Collapse long user messages -->
+          <label class="ls-checkbox-row">
+            <div class="ls-checkbox-wrapper">
+              <input
+                type="checkbox"
+                id="collapseLongUserMessagesCheckbox"
+                class="ls-checkbox-input"
+                aria-label="Collapse long user messages"
+              >
+              <div class="ls-checkbox-box">
+                <svg class="ls-checkbox-check" viewBox="0 0 12 12" fill="none">
+                  <path d="M2 6l3 3 5-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </div>
+            </div>
+            <div class="ls-checkbox-label-group">
+              <span class="ls-checkbox-label">Collapse long user messages</span>
+              <span class="ls-checkbox-description">Reduce lag in long chats</span>
+            </div>
+          </label>
+
         </div>
       </section>
 

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -34,6 +34,7 @@ let keepSlider: HTMLInputElement;
 let keepValue: HTMLElement;
 let sliderTrackFill: HTMLElement;
 let showStatusBarCheckbox: HTMLInputElement | null;
+let collapseLongUserMessagesCheckbox: HTMLInputElement | null;
 let debugCheckbox: HTMLInputElement | null;
 let debugGroup: HTMLElement | null;
 let statusElement: HTMLElement;
@@ -163,6 +164,9 @@ async function initialize(): Promise<void> {
 
   // Get optional UI elements (may not exist in all configurations)
   showStatusBarCheckbox = getOptionalElement<HTMLInputElement>('showStatusBarCheckbox');
+  collapseLongUserMessagesCheckbox = getOptionalElement<HTMLInputElement>(
+    'collapseLongUserMessagesCheckbox'
+  );
   debugCheckbox = getOptionalElement<HTMLInputElement>('debugCheckbox');
   debugGroup = getOptionalElement<HTMLElement>('debugGroup');
   retentionCard = getOptionalElement<HTMLElement>('retentionCard');
@@ -201,6 +205,9 @@ async function initialize(): Promise<void> {
   if (showStatusBarCheckbox) {
     showStatusBarCheckbox.addEventListener('change', handleShowStatusBarToggle);
   }
+  if (collapseLongUserMessagesCheckbox) {
+    collapseLongUserMessagesCheckbox.addEventListener('change', handleCollapseLongUserMessagesToggle);
+  }
   if (debugCheckbox) {
     debugCheckbox.addEventListener('change', handleDebugToggle);
   }
@@ -227,6 +234,9 @@ async function loadSettings(): Promise<void> {
 
     if (showStatusBarCheckbox) {
       showStatusBarCheckbox.checked = settings.showStatusBar;
+    }
+    if (collapseLongUserMessagesCheckbox) {
+      collapseLongUserMessagesCheckbox.checked = settings.collapseLongUserMessages;
     }
     if (debugCheckbox) {
       debugCheckbox.checked = settings.debug;
@@ -308,6 +318,15 @@ async function handleKeepSliderChange(): Promise<void> {
 function handleShowStatusBarToggle(): void {
   if (showStatusBarCheckbox) {
     void updateSettings({ showStatusBar: showStatusBarCheckbox.checked });
+  }
+}
+
+/**
+ * Handle collapse long user messages toggle
+ */
+function handleCollapseLongUserMessagesToggle(): void {
+  if (collapseLongUserMessagesCheckbox) {
+    void updateSettings({ collapseLongUserMessages: collapseLongUserMessagesCheckbox.checked });
   }
 }
 

--- a/extension/src/shared/constants.ts
+++ b/extension/src/shared/constants.ts
@@ -14,6 +14,7 @@ export const DEFAULT_SETTINGS: Readonly<LsSettings> = {
   enabled: true,
   keep: 10,
   showStatusBar: true,
+  collapseLongUserMessages: true,
   debug: false,
   ultraLean: false,
 } as const;

--- a/extension/src/shared/storage.ts
+++ b/extension/src/shared/storage.ts
@@ -30,6 +30,8 @@ export function validateSettings(input: Partial<LsSettings>): LsSettings {
       Math.min(VALIDATION.MAX_KEEP, input.keep ?? DEFAULT_SETTINGS.keep)
     ),
     showStatusBar: input.showStatusBar ?? DEFAULT_SETTINGS.showStatusBar,
+    collapseLongUserMessages:
+      input.collapseLongUserMessages ?? DEFAULT_SETTINGS.collapseLongUserMessages,
     debug: input.debug ?? DEFAULT_SETTINGS.debug,
     ultraLean: input.ultraLean ?? DEFAULT_SETTINGS.ultraLean,
   };

--- a/extension/src/shared/types.ts
+++ b/extension/src/shared/types.ts
@@ -12,6 +12,7 @@ export interface LsSettings {
   enabled: boolean; // Toggle trimming on/off
   keep: number; // Message retention limit (1-100)
   showStatusBar: boolean; // Show in-page status bar with trimming stats
+  collapseLongUserMessages: boolean; // Collapse long user messages in UI (presentation-only)
   debug: boolean; // Enable debug logging
   ultraLean: boolean; // Enable aggressive performance optimizations (adds .ls-ultra-lean class)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "light-session",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "light-session",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "light-session",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "type": "module",
   "description": "LightSession Pro - Browser extension to optimize ChatGPT performance",
   "engines": {

--- a/tests/unit/constants.test.ts
+++ b/tests/unit/constants.test.ts
@@ -66,6 +66,10 @@ describe('DEFAULT_SETTINGS', () => {
     expect(typeof DEFAULT_SETTINGS.showStatusBar).toBe('boolean');
   });
 
+  it('collapseLongUserMessages is a boolean', () => {
+    expect(typeof DEFAULT_SETTINGS.collapseLongUserMessages).toBe('boolean');
+  });
+
   it('debug is a boolean', () => {
     expect(typeof DEFAULT_SETTINGS.debug).toBe('boolean');
   });

--- a/tests/unit/popup.test.ts
+++ b/tests/unit/popup.test.ts
@@ -47,6 +47,7 @@ describe('popup settings loading', () => {
       enabled: true,
       keep: 15,
       showStatusBar: true,
+      collapseLongUserMessages: true,
       debug: false,
       ultraLean: false,
       version: 1,

--- a/tests/unit/storage.test.ts
+++ b/tests/unit/storage.test.ts
@@ -44,6 +44,7 @@ describe('validateSettings', () => {
     expect(result.enabled).toBe(DEFAULT_SETTINGS.enabled);
     expect(result.keep).toBe(DEFAULT_SETTINGS.keep);
     expect(result.showStatusBar).toBe(DEFAULT_SETTINGS.showStatusBar);
+    expect(result.collapseLongUserMessages).toBe(DEFAULT_SETTINGS.collapseLongUserMessages);
     expect(result.debug).toBe(DEFAULT_SETTINGS.debug);
     expect(result.ultraLean).toBe(DEFAULT_SETTINGS.ultraLean);
   });
@@ -53,6 +54,7 @@ describe('validateSettings', () => {
       enabled: false,
       keep: 20,
       showStatusBar: false,
+      collapseLongUserMessages: false,
       debug: true,
       ultraLean: true,
     };
@@ -62,6 +64,7 @@ describe('validateSettings', () => {
     expect(result.enabled).toBe(false);
     expect(result.keep).toBe(20);
     expect(result.showStatusBar).toBe(false);
+    expect(result.collapseLongUserMessages).toBe(false);
     expect(result.debug).toBe(true);
     expect(result.ultraLean).toBe(true);
   });
@@ -97,6 +100,7 @@ describe('validateSettings', () => {
     expect(result.enabled).toBe(false);
     expect(result.keep).toBe(DEFAULT_SETTINGS.keep);
     expect(result.showStatusBar).toBe(DEFAULT_SETTINGS.showStatusBar);
+    expect(result.collapseLongUserMessages).toBe(DEFAULT_SETTINGS.collapseLongUserMessages);
     expect(result.debug).toBe(DEFAULT_SETTINGS.debug);
   });
 

--- a/tests/unit/user-collapse.test.ts
+++ b/tests/unit/user-collapse.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Unit tests for user-collapse.ts (Vitest + happy-dom)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { installUserCollapse } from '../../extension/src/content/user-collapse';
+
+type MockMutation = {
+  type: string;
+  addedNodes: Node[];
+};
+
+class MockMutationObserver {
+  static instances: MockMutationObserver[] = [];
+  cb: MutationCallback;
+  disconnected = false;
+  observed: Array<{ target: Node; options?: MutationObserverInit }> = [];
+
+  constructor(cb: MutationCallback) {
+    this.cb = cb;
+    MockMutationObserver.instances.push(this);
+  }
+
+  observe(target: Node, options?: MutationObserverInit): void {
+    this.observed.push({ target, options });
+  }
+
+  disconnect(): void {
+    this.disconnected = true;
+  }
+
+  trigger(mutations: MockMutation[]): void {
+    this.cb(mutations as unknown as MutationRecord[], this as unknown as MutationObserver);
+  }
+}
+
+function mockLayout(el: HTMLElement, opts: { scrollHeight?: number; clientHeight?: number; rectHeight?: number }) {
+  if (typeof opts.scrollHeight === 'number') {
+    Object.defineProperty(el, 'scrollHeight', {
+      value: opts.scrollHeight,
+      configurable: true,
+    });
+  }
+  if (typeof opts.clientHeight === 'number') {
+    Object.defineProperty(el, 'clientHeight', {
+      value: opts.clientHeight,
+      configurable: true,
+    });
+  }
+  if (typeof opts.rectHeight === 'number') {
+    el.getBoundingClientRect = () =>
+      ({
+        x: 0,
+        y: 0,
+        width: 100,
+        height: opts.rectHeight!,
+        top: 0,
+        left: 0,
+        right: 100,
+        bottom: opts.rectHeight!,
+        toJSON: () => ({}),
+      }) as DOMRect;
+  }
+}
+
+describe('user-collapse', () => {
+  const originalMO = globalThis.MutationObserver;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    MockMutationObserver.instances = [];
+
+    // Ensure module considers this a supported host.
+    window.location.href = 'https://chatgpt.com/';
+
+    // Stub MutationObserver + rAF (run immediately).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    globalThis.MutationObserver = MockMutationObserver as any;
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+      cb(0);
+      return 1;
+    });
+  });
+
+  afterEach(() => {
+    globalThis.MutationObserver = originalMO;
+    vi.restoreAllMocks();
+  });
+
+  it('adds toggle + collapses by default for long user messages', () => {
+    document.body.innerHTML = `
+      <main style="overflow-y:auto">
+        <div data-testid="conversation-turns">
+          <div data-message-author-role="user" data-message-id="m1">
+            <div class="user-message-bubble-color">
+              <div class="whitespace-pre-wrap">Hello</div>
+            </div>
+          </div>
+        </div>
+      </main>
+    `;
+
+    const main = document.querySelector('main') as HTMLElement;
+    mockLayout(main, { scrollHeight: 2000, clientHeight: 800 });
+
+    const text = document.querySelector('.whitespace-pre-wrap') as HTMLElement;
+    mockLayout(text, { scrollHeight: 1200, clientHeight: 120, rectHeight: 1200 });
+
+    const ctrl = installUserCollapse();
+    ctrl.enable();
+
+    const bubble = document.querySelector('.user-message-bubble-color') as HTMLElement;
+    const btn = bubble.querySelector('button.ls-uc-toggle') as HTMLButtonElement;
+
+    expect(btn).not.toBeNull();
+    expect(btn.getAttribute('aria-expanded')).toBe('false');
+    expect(bubble.getAttribute('data-ls-uc-state')).toBe('collapsed');
+    expect(btn.getAttribute('aria-controls')).toBe(text.id);
+    expect(text.classList.contains('ls-uc-text')).toBe(true);
+  });
+
+  it('does not add toggle for short user messages', () => {
+    document.body.innerHTML = `
+      <main style="overflow-y:auto">
+        <div data-testid="conversation-turns">
+          <div data-message-author-role="user" data-message-id="m2">
+            <div class="user-message-bubble-color">
+              <div class="whitespace-pre-wrap">Short</div>
+            </div>
+          </div>
+        </div>
+      </main>
+    `;
+
+    const main = document.querySelector('main') as HTMLElement;
+    mockLayout(main, { scrollHeight: 1200, clientHeight: 800 });
+
+    const text = document.querySelector('.whitespace-pre-wrap') as HTMLElement;
+    mockLayout(text, { scrollHeight: 160, clientHeight: 160, rectHeight: 160 });
+
+    const ctrl = installUserCollapse();
+    ctrl.enable();
+
+    const bubble = document.querySelector('.user-message-bubble-color') as HTMLElement;
+    expect(bubble.querySelector('button.ls-uc-toggle')).toBeNull();
+  });
+
+  it('toggle flips aria-expanded + state attribute', () => {
+    document.body.innerHTML = `
+      <main style="overflow-y:auto">
+        <div data-testid="conversation-turns">
+          <div data-message-author-role="user" data-message-id="m3">
+            <div class="user-message-bubble-color">
+              <div class="whitespace-pre-wrap">Long</div>
+            </div>
+          </div>
+        </div>
+      </main>
+    `;
+
+    const main = document.querySelector('main') as HTMLElement;
+    mockLayout(main, { scrollHeight: 2000, clientHeight: 800 });
+    Object.defineProperty(main, 'scrollTop', { value: 100, writable: true, configurable: true });
+
+    const text = document.querySelector('.whitespace-pre-wrap') as HTMLElement;
+    mockLayout(text, { scrollHeight: 1200, clientHeight: 120, rectHeight: 1200 });
+
+    const ctrl = installUserCollapse();
+    ctrl.enable();
+
+    const bubble = document.querySelector('.user-message-bubble-color') as HTMLElement;
+    const btn = bubble.querySelector('button.ls-uc-toggle') as HTMLButtonElement;
+
+    btn.click();
+    expect(btn.getAttribute('aria-expanded')).toBe('true');
+    expect(bubble.getAttribute('data-ls-uc-state')).toBe('expanded');
+
+    btn.click();
+    expect(btn.getAttribute('aria-expanded')).toBe('false');
+    expect(bubble.getAttribute('data-ls-uc-state')).toBe('collapsed');
+  });
+
+  it('does not duplicate toggles when processing the same message again', () => {
+    document.body.innerHTML = `
+      <main style="overflow-y:auto">
+        <div data-testid="conversation-turns" id="turns">
+          <div data-message-author-role="user" data-message-id="m4" id="root">
+            <div class="user-message-bubble-color">
+              <div class="whitespace-pre-wrap">Long</div>
+            </div>
+          </div>
+        </div>
+      </main>
+    `;
+
+    const main = document.querySelector('main') as HTMLElement;
+    mockLayout(main, { scrollHeight: 2000, clientHeight: 800 });
+
+    const text = document.querySelector('.whitespace-pre-wrap') as HTMLElement;
+    mockLayout(text, { scrollHeight: 1200, clientHeight: 120, rectHeight: 1200 });
+
+    const ctrl = installUserCollapse();
+    ctrl.enable();
+
+    const bubble = document.querySelector('.user-message-bubble-color') as HTMLElement;
+    expect(bubble.querySelectorAll('button.ls-uc-toggle').length).toBe(1);
+
+    const mo = MockMutationObserver.instances[0];
+    const root = document.getElementById('root') as HTMLElement;
+    mo.trigger([{ type: 'childList', addedNodes: [root] }]);
+
+    expect(bubble.querySelectorAll('button.ls-uc-toggle').length).toBe(1);
+  });
+
+  it('teardown disconnects observer and removes toggles', () => {
+    document.body.innerHTML = `
+      <main style="overflow-y:auto">
+        <div data-testid="conversation-turns">
+          <div data-message-author-role="user" data-message-id="m5">
+            <div class="user-message-bubble-color">
+              <div class="whitespace-pre-wrap">Long</div>
+            </div>
+          </div>
+        </div>
+      </main>
+    `;
+
+    const main = document.querySelector('main') as HTMLElement;
+    mockLayout(main, { scrollHeight: 2000, clientHeight: 800 });
+
+    const text = document.querySelector('.whitespace-pre-wrap') as HTMLElement;
+    mockLayout(text, { scrollHeight: 1200, clientHeight: 120, rectHeight: 1200 });
+
+    const ctrl = installUserCollapse();
+    ctrl.enable();
+
+    const bubble = document.querySelector('.user-message-bubble-color') as HTMLElement;
+    expect(bubble.querySelector('button.ls-uc-toggle')).not.toBeNull();
+
+    const mo = MockMutationObserver.instances[0];
+    ctrl.teardown();
+
+    expect(mo.disconnected).toBe(true);
+    expect(bubble.querySelector('button.ls-uc-toggle')).toBeNull();
+    expect(document.getElementById('lightsession-user-collapse-styles')).toBeNull();
+  });
+});


### PR DESCRIPTION
Adds per-feature setting (default on) to enable/disable collapsing long user messages from the popup.

Fixes #12

- New setting: collapseLongUserMessages (default true)
- Content script gates user-collapse on enabled && collapseLongUserMessages
- Popup checkbox added
- Version bump to 1.7.0
- Tests updated
