### PR TITLE
fix(page-script): intercept only conversation endpoints

### DIFF
--- a/extension/src/page/page-script.ts
+++ b/extension/src/page/page-script.ts
@@ -186,12 +186,19 @@ function isConversationRequest(method: string, url: URL): boolean {
     return false;
   }
 
-  // Only /backend-api/ endpoints
-  if (!url.pathname.startsWith('/backend-api/')) {
-    return false;
-  }
-
-  return true;
+  // Only endpoints that return the conversation tree we can trim.
+  // ChatGPT performs many GET /backend-api/* requests on load (/me, /models, /settings, etc.).
+  // Intercepting those adds unnecessary overhead (clone/json) and config gating delay.
+  //
+  // Allowed:
+  // - /backend-api/conversation/<id>
+  // - /backend-api/shared_conversation/<id> (share links)
+  //
+  // Explicitly excluded by pattern (extra path segments):
+  // - /backend-api/conversation/<id>/stream_status
+  // - /backend-api/conversation/<id>/textdocs
+  const path = url.pathname;
+  return /^\/backend-api\/(conversation|shared_conversation)\/[^/]+\/?$/.test(path);
 }
 
 /**

--- a/tests/unit/page-script.test.ts
+++ b/tests/unit/page-script.test.ts
@@ -82,20 +82,29 @@ describe('isConversationRequest logic', () => {
   // Testing the logic that would be in isConversationRequest
   const isConversationRequest = (method: string, pathname: string): boolean => {
     if (method !== 'GET') return false;
-    if (!pathname.startsWith('/backend-api/')) return false;
-    return true;
+    return /^\/backend-api\/(conversation|shared_conversation)\/[^/]+\/?$/.test(pathname);
   };
 
-  it('returns true for GET /backend-api/ requests', () => {
+  it('returns true only for conversation endpoints', () => {
     expect(isConversationRequest('GET', '/backend-api/conversation/123')).toBe(true);
-    expect(isConversationRequest('GET', '/backend-api/conversation')).toBe(true);
-    expect(isConversationRequest('GET', '/backend-api/')).toBe(true);
+    expect(isConversationRequest('GET', '/backend-api/conversation/123/')).toBe(true);
+    expect(isConversationRequest('GET', '/backend-api/shared_conversation/abc-xyz')).toBe(true);
   });
 
   it('returns false for non-GET methods', () => {
     expect(isConversationRequest('POST', '/backend-api/conversation')).toBe(false);
     expect(isConversationRequest('PUT', '/backend-api/conversation')).toBe(false);
     expect(isConversationRequest('DELETE', '/backend-api/conversation')).toBe(false);
+  });
+
+  it('returns false for non-conversation backend-api paths', () => {
+    expect(isConversationRequest('GET', '/backend-api/')).toBe(false);
+    expect(isConversationRequest('GET', '/backend-api/conversation')).toBe(false);
+    expect(isConversationRequest('GET', '/backend-api/me')).toBe(false);
+    expect(isConversationRequest('GET', '/backend-api/settings/user')).toBe(false);
+    expect(isConversationRequest('GET', '/backend-api/models')).toBe(false);
+    expect(isConversationRequest('GET', '/backend-api/conversation/123/stream_status')).toBe(false);
+    expect(isConversationRequest('GET', '/backend-api/conversation/123/textdocs')).toBe(false);
   });
 
   it('returns false for non-backend-api paths', () => {


### PR DESCRIPTION
Fix for beads issue `light-session-svr`.

Problem:
- Fetch proxy treated any `GET /backend-api/*` as eligible for interception, causing unnecessary `res.clone()`/`json()` work and `ensureConfigReady()` gating for endpoints like `/me`, `/models`, `/settings/user`, etc.

Change:
- Narrow allowlist to:
  - `GET /backend-api/conversation/<id>`
  - `GET /backend-api/shared_conversation/<id>`

Tests:
- `npm test`
- `npm run lint`
- `npm run build:types`
