### PR TITLE
fix: don't suppress non-LightSession unhandledrejection

### DIFF
--- a/extension/src/content/rejection-filter.ts
+++ b/extension/src/content/rejection-filter.ts
@@ -1,0 +1,49 @@
+/**
+ * Helpers for filtering global error events so we don't suppress site errors.
+ *
+ * The content script can observe `window` errors/rejections originating from the page.
+ * Calling `preventDefault()` on these events suppresses the browser's default reporting,
+ * so we must only suppress errors that are clearly caused by LightSession itself.
+ */
+
+export function isLightSessionRejection(
+  reason: unknown,
+  extensionUrlPrefix?: string,
+): boolean {
+  const parts: string[] = [];
+
+  if (typeof reason === 'string') {
+    parts.push(reason);
+  } else if (reason instanceof Error) {
+    if (typeof reason.message === 'string') parts.push(reason.message);
+    if (typeof reason.stack === 'string') parts.push(reason.stack);
+    if (typeof reason.name === 'string') parts.push(reason.name);
+  } else if (typeof reason === 'object' && reason !== null) {
+    const r = reason as Record<string, unknown>;
+    if (typeof r.message === 'string') parts.push(r.message);
+    if (typeof r.stack === 'string') parts.push(r.stack);
+    if (typeof r.name === 'string') parts.push(r.name);
+    // Some browsers use different keys on Error-like objects.
+    if (typeof r.filename === 'string') parts.push(r.filename);
+    if (typeof r.fileName === 'string') parts.push(r.fileName);
+  }
+
+  if (parts.length === 0) return false;
+
+  const haystack = parts.join('\n');
+
+  // The most reliable signal: our own extension base URL.
+  // If we have it, prefer it exclusively to avoid suppressing unrelated site errors.
+  if (extensionUrlPrefix) {
+    return haystack.includes(extensionUrlPrefix);
+  }
+
+  // Fallback heuristics (only used if runtime URL isn't available).
+  // Our logger prefix sometimes appears in thrown messages.
+  if (haystack.includes('LS:')) return true;
+
+  // Useful in dev builds / source maps.
+  if (haystack.includes('light-session')) return true;
+
+  return false;
+}

--- a/tests/unit/rejection-filter.test.ts
+++ b/tests/unit/rejection-filter.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { isLightSessionRejection } from '../../extension/src/content/rejection-filter';
+
+describe('isLightSessionRejection', () => {
+  it('returns false for empty/unknown reasons', () => {
+    expect(isLightSessionRejection(undefined)).toBe(false);
+    expect(isLightSessionRejection(null)).toBe(false);
+    expect(isLightSessionRejection(123)).toBe(false);
+    expect(isLightSessionRejection({})).toBe(false);
+  });
+
+  it('matches when reason string contains LS:', () => {
+    expect(isLightSessionRejection('LS: boom')).toBe(true);
+  });
+
+  it('does not match LS: in message when extension URL is provided but not present', () => {
+    const prefix = 'chrome-extension://abc123/';
+    expect(isLightSessionRejection('LS: boom', prefix)).toBe(false);
+  });
+
+  it('matches when Error.stack contains the extension base URL', () => {
+    const prefix = 'chrome-extension://abc123/';
+    const err = new Error('nope');
+    // Simulate a stack that points at our bundled content script URL.
+    err.stack = `Error: nope\n    at doThing (${prefix}dist/content.js:1:1)`;
+    expect(isLightSessionRejection(err, prefix)).toBe(true);
+  });
+
+  it('does not match non-LightSession errors by default', () => {
+    const err = new Error('Some site error');
+    err.stack = `Error: Some site error\n    at foo (https://chatgpt.com/app.js:1:1)`;
+    expect(isLightSessionRejection(err)).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes bead light-session-7wz.

Problem: content script called preventDefault() for all window 'unhandledrejection' events, suppressing default DevTools reporting for unrelated site errors.

Change: only call preventDefault() when the rejection is clearly attributable to LightSession (extension URL in stack/message). Still logs LightSession-ish errors; does not mask site errors.

- Adds filter helper: extension/src/content/rejection-filter.ts
- Updates handler: extension/src/content/content.ts
- Adds unit tests: tests/unit/rejection-filter.test.ts

Verification:
- npm test
- npm run lint
- npm run build:chrome
- Manual check in Brave via CDP :9222 that page-context rejections are still reported.