### PR TITLE
Fix collapse of long user messages after switching chats

### DIFF
--- a/extension/src/content/content.ts
+++ b/extension/src/content/content.ts
@@ -235,40 +235,62 @@ function handleStorageChange(
  * Resets accumulated trim count on chat changes.
  */
 function setupNavigationDetection(): void {
-  let lastPath = location.pathname;
+  // Use full href as the navigation key. ChatGPT can navigate without changing pathname.
+  let lastUrl = location.href;
+  let navScheduled = false;
+
+  const scheduleNavSideEffects = (source: 'popstate' | 'pushState' | 'replaceState'): void => {
+    // Coalesce rapid history events into a single tick.
+    if (navScheduled) return;
+    navScheduled = true;
+    Promise.resolve().then(() => {
+      navScheduled = false;
+
+      // Keep the key updated even if we decide not to run side effects.
+      lastUrl = location.href;
+
+      logDebug(`${source} navigation:`, lastUrl);
+      resetAccumulatedTrimmed();
+      refreshStatusBar();
+
+      // Re-bind DOM observers for per-chat containers (SPA navigation can replace the message list DOM).
+      // Make the settings intent explicit; userCollapse being non-null is an implementation detail.
+      if (currentSettings?.enabled && currentSettings.collapseLongUserMessages) {
+        userCollapse?.enable();
+      }
+    });
+  };
 
   // Listen for popstate events
   window.addEventListener('popstate', () => {
-    if (location.pathname !== lastPath) {
-      lastPath = location.pathname;
-      logDebug('Popstate navigation:', lastPath);
-      resetAccumulatedTrimmed();
-      refreshStatusBar();
+    if (location.href !== lastUrl) {
+      scheduleNavSideEffects('popstate');
     }
   });
 
   // Patch history methods for SPA navigation detection
+  // Guard against double patching (e.g. extension reload / unexpected reinjection).
+  const PATCH_FLAG = '__lightsession_patched_history__';
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if ((history as any)[PATCH_FLAG]) return;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (history as any)[PATCH_FLAG] = true;
+
   const originalPushState = history.pushState.bind(history);
   const originalReplaceState = history.replaceState.bind(history);
 
   history.pushState = function (...args: Parameters<typeof history.pushState>) {
     const result = originalPushState(...args);
-    if (location.pathname !== lastPath) {
-      lastPath = location.pathname;
-      logDebug('PushState navigation:', lastPath);
-      resetAccumulatedTrimmed();
-      refreshStatusBar();
+    if (location.href !== lastUrl) {
+      scheduleNavSideEffects('pushState');
     }
     return result;
   };
 
   history.replaceState = function (...args: Parameters<typeof history.replaceState>) {
     const result = originalReplaceState(...args);
-    if (location.pathname !== lastPath) {
-      lastPath = location.pathname;
-      logDebug('ReplaceState navigation:', lastPath);
-      resetAccumulatedTrimmed();
-      refreshStatusBar();
+    if (location.href !== lastUrl) {
+      scheduleNavSideEffects('replaceState');
     }
     return result;
   };

--- a/extension/src/content/content.ts
+++ b/extension/src/content/content.ts
@@ -243,7 +243,7 @@ function setupNavigationDetection(): void {
     // Coalesce rapid history events into a single tick.
     if (navScheduled) return;
     navScheduled = true;
-    Promise.resolve().then(() => {
+    queueMicrotask(() => {
       navScheduled = false;
 
       // Keep the key updated even if we decide not to run side effects.
@@ -271,10 +271,9 @@ function setupNavigationDetection(): void {
   // Patch history methods for SPA navigation detection
   // Guard against double patching (e.g. extension reload / unexpected reinjection).
   const PATCH_FLAG = '__lightsession_patched_history__';
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if ((history as any)[PATCH_FLAG]) return;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (history as any)[PATCH_FLAG] = true;
+  const patchScope = window as unknown as Record<string, unknown>;
+  if (patchScope[PATCH_FLAG] === true) return;
+  patchScope[PATCH_FLAG] = true;
 
   const originalPushState = history.pushState.bind(history);
   const originalReplaceState = history.replaceState.bind(history);


### PR DESCRIPTION
### Problem\nLong user messages could fail to collapse after switching chats in ChatGPT SPA until a full page refresh.\n\n### Fix\n- Rebind user-collapse on SPA navigation (popstate/pushState/replaceState) with href-based detection and guard against double patching.\n- Handle DOM recycling via attribute-mutation observation and container replacement reattach.\n- Harden unit tests (observer selection + teardown).\n\n### Testing\n- Unit: npm test\n- Manual E2E: Brave via CDP (agent-browser connect 9222), verified toggle appears after switching chats without refresh.