### PR TITLE
Extend collapsible message UI to assistant responses and keep only the latest expanded

### DIFF
--- a/tests/unit/user-collapse.test.ts
+++ b/tests/unit/user-collapse.test.ts
@@ -199,6 +199,124 @@ describe('user-collapse', () => {
     expect(bubble.getAttribute('data-ls-uc-state')).toBe('collapsed');
   });
 
+
+  it('starts long assistant messages expanded by default', () => {
+    document.body.innerHTML = `
+      <main style="overflow-y:auto">
+        <div data-testid="conversation-turns">
+          <div data-message-author-role="assistant" data-message-id="a1">
+            <div>
+              <div class="markdown prose">Long assistant response</div>
+            </div>
+          </div>
+        </div>
+      </main>
+    `;
+
+    const main = document.querySelector('main') as HTMLElement;
+    mockLayout(main, { scrollHeight: 2000, clientHeight: 800 });
+
+    const text = document.querySelector('.markdown.prose') as HTMLElement;
+    mockLayout(text, { scrollHeight: 1200, clientHeight: 120, rectHeight: 1200 });
+
+    const ctrl = installUserCollapse();
+    ctrl.enable();
+    lastCtrl = ctrl;
+
+    const bubble = text.parentElement as HTMLElement;
+    const btn = bubble.querySelector('button.ls-uc-toggle') as HTMLButtonElement;
+
+    expect(btn).not.toBeNull();
+    expect(btn.getAttribute('aria-expanded')).toBe('true');
+    expect(bubble.getAttribute('data-ls-uc-state')).toBe('expanded');
+  });
+
+
+  it('keeps only the latest long assistant message expanded', () => {
+    document.body.innerHTML = `
+      <main style="overflow-y:auto">
+        <div data-testid="conversation-turns">
+          <div data-message-author-role="assistant" data-message-id="a1">
+            <div>
+              <div class="markdown prose" id="a1-text">Long assistant response 1</div>
+            </div>
+          </div>
+          <div data-message-author-role="assistant" data-message-id="a2">
+            <div>
+              <div class="markdown prose" id="a2-text">Long assistant response 2</div>
+            </div>
+          </div>
+        </div>
+      </main>
+    `;
+
+    const main = document.querySelector('main') as HTMLElement;
+    mockLayout(main, { scrollHeight: 2000, clientHeight: 800 });
+
+    const text1 = document.getElementById('a1-text') as HTMLElement;
+    const text2 = document.getElementById('a2-text') as HTMLElement;
+    mockLayout(text1, { scrollHeight: 1200, clientHeight: 120, rectHeight: 1200 });
+    mockLayout(text2, { scrollHeight: 1300, clientHeight: 130, rectHeight: 1300 });
+
+    const ctrl = installUserCollapse();
+    ctrl.enable();
+    lastCtrl = ctrl;
+
+    const bubble1 = text1.parentElement as HTMLElement;
+    const bubble2 = text2.parentElement as HTMLElement;
+
+    expect(bubble1.getAttribute('data-ls-uc-state')).toBe('collapsed');
+    expect(bubble2.getAttribute('data-ls-uc-state')).toBe('expanded');
+  });
+
+  it('collapses previous assistant message when a newer assistant response arrives', () => {
+    document.body.innerHTML = `
+      <main style="overflow-y:auto">
+        <div data-testid="conversation-turns" id="turns">
+          <div data-message-author-role="assistant" data-message-id="a1" id="a1-root">
+            <div>
+              <div class="markdown prose" id="a1-text">Long assistant response 1</div>
+            </div>
+          </div>
+        </div>
+      </main>
+    `;
+
+    const main = document.querySelector('main') as HTMLElement;
+    mockLayout(main, { scrollHeight: 2000, clientHeight: 800 });
+
+    const text1 = document.getElementById('a1-text') as HTMLElement;
+    mockLayout(text1, { scrollHeight: 1200, clientHeight: 120, rectHeight: 1200 });
+
+    const ctrl = installUserCollapse();
+    ctrl.enable();
+    lastCtrl = ctrl;
+
+    const turns = document.getElementById('turns') as HTMLElement;
+    const mo = getObserverForContainer(turns);
+
+    const newRoot = document.createElement('div');
+    newRoot.setAttribute('data-message-author-role', 'assistant');
+    newRoot.setAttribute('data-message-id', 'a2');
+    const wrap = document.createElement('div');
+    const text2 = document.createElement('div');
+    text2.className = 'markdown prose';
+    text2.id = 'a2-text';
+    text2.textContent = 'Long assistant response 2';
+    wrap.appendChild(text2);
+    newRoot.appendChild(wrap);
+    turns.appendChild(newRoot);
+
+    mockLayout(text2, { scrollHeight: 1300, clientHeight: 130, rectHeight: 1300 });
+
+    mo.trigger([{ type: 'childList', addedNodes: [newRoot] }]);
+
+    const bubble1 = text1.parentElement as HTMLElement;
+    const bubble2 = text2.parentElement as HTMLElement;
+    expect(bubble1.getAttribute('data-ls-uc-state')).toBe('collapsed');
+    expect(bubble2.getAttribute('data-ls-uc-state')).toBe('expanded');
+  });
+
   it('does not duplicate toggles when processing the same message again', () => {
     document.body.innerHTML = `
       <main style="overflow-y:auto">


### PR DESCRIPTION
## Motivation

The existing message-collapsing UI was originally focused on user messages, but it needed to be extended consistently to assistant responses as well.

From a UX perspective, keeping every assistant response expanded would reduce readability and make the conversation view feel dense. To balance readability and screen efficiency, the intended behavior is to keep only the most recent assistant response expanded by default.

We also needed to make the implementation more resilient to ChatGPT DOM variations, since assistant messages do not always include `.user-message-bubble-color`. This required stronger container discovery logic.

## Changes

* Expanded the collapsing target selector from user-only elements to a new `COLLAPSIBLE_ROOT_SELECTOR` that includes both user and assistant messages.
* Improved the initial state logic for assistant messages by introducing `isLatestAssistantRoot` and `shouldStartExpanded`, so that only the latest assistant root starts expanded.
* Added `normalizeAssistantExpansion()` to normalize assistant message states after batch processing, ensuring that only the most recent assistant response remains expanded while earlier responses are collapsed.
* Improved support for assistant-side DOM variations by using `deriveBubbleContainer()`, allowing the toggle UI to be attached and removed reliably even when the bubble class is missing.
* Preserved the existing collapse behavior, including clamp, fade, toggle, and scroll position retention.

## Testing

* Type check: `npm run build:types`
* Unit tests: `npm test`

Additional and updated tests were added for the following scenarios:

* long assistant messages start expanded by default
* when multiple assistant messages exist, only the latest one is expanded
* when a new assistant response arrives, the previous response is automatically collapsed and the latest response remains expanded

## Notes

* This work was developed with **Codex (GPT-5.2-Codex)**.
