### PR TITLE
fix(status-bar): adjust position of status bar for better visibility and not to overlap over the input message field

### DIFF
--- a/extension/src/content/status-bar.ts
+++ b/extension/src/content/status-bar.ts
@@ -53,7 +53,7 @@ function applyStatusBarStyles(bar: HTMLElement): void {
   Object.assign(bar.style, {
     position: 'fixed',
     bottom: '3.5px',
-    right: '20px',
+    right: '24px',
     zIndex: '10000',
     padding: '4px 10px',
     fontSize: '11px',


### PR DESCRIPTION
Minor adjustment of the status bar position so that it doesn't overlap over the chat input message field.

<details>
<summary>Before</summary>
<img width="427" height="153" alt="image" src="https://github.com/user-attachments/assets/620e9483-f451-404c-b28a-dba2fa32221e" />
</details>

<details>
<summary>After</summary>
<img width="421" height="132" alt="image" src="https://github.com/user-attachments/assets/6c0bd443-e94e-48da-8490-1c3cc3f5518d" />
</details>
